### PR TITLE
#228-fixed-NotCorrespondingTitle

### DIFF
--- a/src/constants/translations/en/guest-home-page.json
+++ b/src/constants/translations/en/guest-home-page.json
@@ -23,7 +23,7 @@
   },
   "whatCanYouDo": {
     "title": "What can you do",
-    "description": "Whether you’re looking for a tutor or to looking become one – you’ve come to the right place.",
+    "description": "Whether you’re looking for a tutor or looking to become one – you’ve come to the right place.",
     "learn": {
       "title": "Learn from experts",
       "description": "Learning from experts is a shortcut to mastery. Their knowledge and experience can guide you, unlocking your potential. Don't put off until tomorrow. Embrace it! 🌟",


### PR DESCRIPTION
Linked issue: [#228](https://github.com/orgs/Space2Study-UA-4427-4288-02-02/projects/2/views/1?pane=issue&itemId=130319215&issue=Space2Study-UA-4427-4288-02-02%7CIssues%7C228)
Fixed the bug with not corresponding to the mockup title description text in the home page “What can you do” block.
**Before fix:**
<img width="1896" height="944" alt="image" src="https://github.com/user-attachments/assets/af9ad56d-e8e3-4bb4-b3cd-fe1cd330048c" />

**After fix:**
<img width="962" height="187" alt="image" src="https://github.com/user-attachments/assets/d0fde8bb-898c-4a75-9afd-aa4f5b3b1b65" />
