### PR TITLE
#240-disableTsRulesForTests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,6 +93,14 @@ module.exports = {
       env: {
         jest: true
       }
+    },
+    {
+      files: ['**/*.test.ts', '**/*.test.tsx', '**/__tests__/**/*.{ts,tsx}'],
+      rules: {
+        '@typescript-eslint/no-unsafe-call': 'off',
+        '@typescript-eslint/no-unsafe-member-access': 'off',
+        '@typescript-eslint/no-unsafe-assignment': 'off'
+      }
     }
   ]
 }


### PR DESCRIPTION
Disable rules for test files via ESLint override.

Added an ESLint override for test files to turn off:
  - @typescript-eslint/no-unsafe-call
  - @typescript-eslint/no-unsafe-member-access
  - @typescript-eslint/no-unsafe-assignment
- Reason: CI fails on tests because Vitest globals (describe/test/expect) are treated as `any` by type-aware rules.