### PR TITLE
#234-inputOverlappedByText

### DIFF
--- a/src/containers/guest-home-page/forgot-password/ForgotPassword.styles.js
+++ b/src/containers/guest-home-page/forgot-password/ForgotPassword.styles.js
@@ -17,7 +17,8 @@ export const styles = {
   titleWithDescription: {
     wrapper: {
       textAlign: 'start',
-      m: 0
+      m: 0,
+      pb: '20px'
     },
     title: {
       typography: 'h5',


### PR DESCRIPTION
Linked issue: [#234](https://github.com/orgs/Space2Study-UA-4427-4288-02-02/projects/2/views/1?pane=issue&itemId=130319229&issue=Space2Study-UA-4427-4288-02-02%7CIssues%7C234)
Fixed bug where input field was overlapped by text in the description on forgot password popup. 
**Before fix:**
<img width="744" height="652" alt="image" src="https://github.com/user-attachments/assets/64af124f-0f44-4dbb-b48f-d665ef329de7" />

**After fix:**
<img width="485" height="250" alt="image" src="https://github.com/user-attachments/assets/fedb02af-d19f-44e0-9d67-67fffa3e635f" />
