### PR TITLE
#75- addPhotoAndSelectOnSubject Step

### DIFF
--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
@@ -18,12 +18,11 @@ const SubjectsStep = ({ btnsBox }) => {
   const { stepData, handleStepData } = useStepContext()
 
   const ctx = stepData?.[STEP_KEY]
-  const data = ctx?.data ?? { category: null, subjects: null }
-  const errors = ctx?.errors ?? {}
-
   useEffect(() => {
+    const data = ctx?.data ?? { category: null, subjects: null }
+    const errors = ctx?.errors ?? {}
     if (!ctx) handleStepData(STEP_KEY, data, errors)
-  }, [])
+  }, [ctx ])
 
   const [categoriesOptions, setCategoriesOptions] = useState([])
   const [subjectsOptions, setSubjectsOptions] = useState([])

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
@@ -1,13 +1,106 @@
+import { useEffect, useState } from 'react'
 import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import { useTranslation } from 'react-i18next'
 
+import AppAutoComplete from '~/components/app-auto-complete/AppAutoComplete'
+import { useStepContext } from '~/context/step-context'
+import { categoryService } from '~/services/category-service'
+import { subjectService } from '~/services/subject-service'
+
+import img from '~/assets/img/tutor-home-page/become-tutor/study-category.svg'
 import { styles } from '~/containers/tutor-home-page/subjects-step/SubjectsStep.styles'
 
+const STEP_KEY = 'subjects'
+
 const SubjectsStep = ({ btnsBox }) => {
+  const { t } = useTranslation()
+  const { stepData, handleStepData } = useStepContext()
+
+  const ctx = stepData?.[STEP_KEY]
+  const data = ctx?.data ?? { category: null, subjects: null }
+  const errors = ctx?.errors ?? {}
+
+  useEffect(() => {
+    if (!ctx) handleStepData(STEP_KEY, data, errors)
+  }, [])
+
+  const [categoriesOptions, setCategoriesOptions] = useState([])
+  const [subjectsOptions, setSubjectsOptions] = useState([])
+  const [loadingCategories, setLoadingCategories] = useState(false)
+  const [loadingSubjects, setLoadingSubjects] = useState(false)
+
+  const updateCategories = (patch) =>
+    handleStepData(STEP_KEY, { ...data, ...patch }, errors)
+
+  const fetchCategories = async () => {
+    if (categoriesOptions.length) return
+    setLoadingCategories(true)
+    try {
+      const res = await categoryService.getCategoriesNames()
+      setCategoriesOptions(res.data ?? [])
+    } finally {
+      setLoadingCategories(false)
+    }
+  }
+
+  const fetchSubjects = async () => {
+    const catId = data.category?._id || data.category?.id || null
+    if (!catId) return
+    setLoadingSubjects(true)
+    try {
+      const res = await subjectService.getSubjectsNames(catId)
+      setSubjectsOptions(res.data ?? [])
+    } finally {
+      setLoadingSubjects(false)
+    }
+  }
+
+  const changeCategory = (_, newValue) => {
+    updateCategories({ category: newValue, subjects: null })
+    setSubjectsOptions([])
+  }
+
   return (
     <Box sx={styles.container}>
+      <Box sx={styles.imgContainer}>
+        <Box alt='Category' component='img' src={img} sx={styles.img} />
+      </Box>
+
       <Box sx={styles.rigthBox}>
-        Subjects step
-        {btnsBox}
+        <Typography sx={styles.title}>
+          {t('becomeTutor.categories.title')}
+        </Typography>
+
+        <Box component={'form'} sx={styles.form}>
+          <AppAutoComplete
+            clearOnEscape
+            loading={loadingCategories}
+            onChange={changeCategory}
+            onOpen={fetchCategories}
+            options={categoriesOptions}
+            textFieldProps={{
+              label: t('becomeTutor.categories.mainSubjectsLabel'),
+              placeholder: t('becomeTutor.categories.mainSubjectsLabel')
+            }}
+            value={data.category}
+          />
+
+          <AppAutoComplete
+            clearOnEscape
+            disabled={!data.category}
+            loading={loadingSubjects}
+            onChange={(_, newValue) => updateCategories({ subjects: newValue })}
+            onOpen={fetchSubjects}
+            options={subjectsOptions}
+            textFieldProps={{
+              label: t('becomeTutor.categories.subjectLabel'),
+              placeholder: t('becomeTutor.categories.subjectLabel')
+            }}
+            value={data.subjects}
+          />
+          {btnsBox}
+        </Box>
       </Box>
     </Box>
   )

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
@@ -8,5 +8,36 @@ export const styles = {
     height: { sm: '485px' },
     paddingBottom: { xs: '30px', sm: '0px' },
     ...fadeAnimation
+  },
+  imgContainer: {
+    display: { xs: 'none', sm: 'none', md: 'flex' },
+    flex: { sm: 1 },
+    maxWidth: { xs: '100%', sm: '432px' },
+    aspectRatio: { xs: '4/3', sm: 'auto' },
+    mb: { xs: '20px', sm: '0' }
+  },
+  img: {
+    width: '100%',
+    objectFit: { xs: 'contain', sm: 'unset' },
+    m: { sm: 0, xs: '0 auto' }
+  },
+  rigthBox: {
+    maxWidth: '432px',
+    display: 'flex',
+    flexDirection: 'column',
+    m: { md: 0, xs: '0 auto' },
+    pt: 0
+  },
+  title: {
+    mb: '16px',
+    fontSize: { xs: '14px', sm: '16px' },
+    lineHeight: { xs: '20px', sm: '24px' },
+    fontWeight: 400,
+    letterSpacing: 0.5
+  },
+  form: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px'
   }
 }


### PR DESCRIPTION
UI for Subjects step.
- Fetch categories on open.
- Fetch subjects on open after category is selected.
- Clear on cross-click (both selects).

<img width="1042" height="650" alt="image" src="https://github.com/user-attachments/assets/3cb52899-8e36-4f41-8b09-4636cee1de5b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Subjects step with two dependent autocompletes: choose a category, then select subjects.
  * Selections persist within the step flow and reflect in real time.
  * Loading indicators and disabled states improve clarity during data fetch.
  * Added localized labels, a header/title, and an illustrative image.
  * Integrated action buttons within the form.

* **Style/UX**
  * Introduced a responsive layout with refined spacing, typography, and image presentation.
  * Enhanced form structure for clarity and accessibility across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->