### PR TITLE
#76-addButtonAndChipsForSubject

### DIFF
--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { useTranslation } from 'react-i18next'
+import { Button, Stack, Chip } from '@mui/material'
 
 import AppAutoComplete from '~/components/app-auto-complete/AppAutoComplete'
 import { useStepContext } from '~/context/step-context'
@@ -13,16 +14,19 @@ import { styles } from '~/containers/tutor-home-page/subjects-step/SubjectsStep.
 
 const STEP_KEY = 'subjects'
 
+const getId = (x) => x?._id || x?.id || x?.value || null
+
 const SubjectsStep = ({ btnsBox }) => {
   const { t } = useTranslation()
   const { stepData, handleStepData } = useStepContext()
 
   const ctx = stepData?.[STEP_KEY]
+  const data = ctx?.data ?? { category: null, subjects: null }
+  const errors = ctx?.errors ?? {}
+
   useEffect(() => {
-    const data = ctx?.data ?? { category: null, subjects: null }
-    const errors = ctx?.errors ?? {}
     if (!ctx) handleStepData(STEP_KEY, data, errors)
-  }, [ctx ])
+  }, [ctx])
 
   const [categoriesOptions, setCategoriesOptions] = useState([])
   const [subjectsOptions, setSubjectsOptions] = useState([])
@@ -56,9 +60,43 @@ const SubjectsStep = ({ btnsBox }) => {
   }
 
   const changeCategory = (_, newValue) => {
-    updateCategories({ category: newValue, subjects: null })
+    updateCategories({
+      category: newValue,
+      subjects: null,
+      selectedSubjects: []
+    })
     setSubjectsOptions([])
   }
+
+  const addCurentSubjectAsChip = () => {
+    const current = data.subjects
+    if (!current) return
+    const id = getId(current)
+    if (!id) return
+
+    const exist = data.selectedSubjects.some((s) => getId(s) === id)
+    if (exist) {
+      updateCategories({ subjects: null })
+      return
+    }
+
+    updateCategories({
+      selectedSubjects: [...(data.selectedSubjects ?? []), current],
+      subjects: null
+    })
+  }
+
+  const removeChip = (id) => {
+    updateCategories({
+      selectedSubjects: (data.selectedSubjects ?? []).filter(
+        (s) => getId(s) !== id
+      )
+    })
+  }
+
+  const canAdd =
+    !!data.subjects &&
+    !data.selectedSubjects?.some((s) => getId(s) === getId(data.subjects))
 
   return (
     <Box sx={styles.container}>
@@ -98,6 +136,38 @@ const SubjectsStep = ({ btnsBox }) => {
             }}
             value={data.subjects}
           />
+
+          <Button
+            disabled={!canAdd}
+            onClick={addCurentSubjectAsChip}
+            sx={styles.addBtn}
+            type='button'
+          >
+            {t('becomeTutor.categories.btnText')}
+          </Button>
+
+          {!!data.selectedSubjects?.length && (
+            <Stack sx={styles.chipWrap}>
+              {data.selectedSubjects.slice(0, 3).map((s) => {
+                const id = getId(s)
+                return (
+                  <Chip
+                    key={id}
+                    label={s?.name ?? ''}
+                    onDelete={() => removeChip(id)}
+                    sx={styles.chip}
+                  />
+                )
+              })}
+              {data.selectedSubjects.length > 3 && (
+                <Chip
+                  label={`+${data.selectedSubjects.length - 3}`}
+                  sx={styles.moreChip}
+                />
+              )}
+            </Stack>
+          )}
+
           {btnsBox}
         </Box>
       </Box>

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
@@ -13,6 +13,7 @@ import img from '~/assets/img/tutor-home-page/become-tutor/study-category.svg'
 import { styles } from '~/containers/tutor-home-page/subjects-step/SubjectsStep.styles'
 
 const STEP_KEY = 'subjects'
+const MAX_VISIBLE_CHIPS = 3
 
 const getId = (x) => x?._id || x?.id || x?.value || null
 
@@ -21,19 +22,23 @@ const SubjectsStep = ({ btnsBox }) => {
   const { stepData, handleStepData } = useStepContext()
 
   const ctx = stepData?.[STEP_KEY]
-  const data = ctx?.data ?? { category: null, subjects: null }
+  const data = ctx?.data ?? {
+    category: null,
+    subjects: null,
+    selectedSubjects: []
+  }
   const errors = ctx?.errors ?? {}
 
   useEffect(() => {
     if (!ctx) handleStepData(STEP_KEY, data, errors)
-  }, [ctx])
+  }, [ctx, handleStepData])
 
   const [categoriesOptions, setCategoriesOptions] = useState([])
   const [subjectsOptions, setSubjectsOptions] = useState([])
   const [loadingCategories, setLoadingCategories] = useState(false)
   const [loadingSubjects, setLoadingSubjects] = useState(false)
 
-  const updateCategories = (patch) =>
+  const updateStep = (patch) =>
     handleStepData(STEP_KEY, { ...data, ...patch }, errors)
 
   const fetchCategories = async () => {
@@ -60,7 +65,7 @@ const SubjectsStep = ({ btnsBox }) => {
   }
 
   const changeCategory = (_, newValue) => {
-    updateCategories({
+    updateStep({
       category: newValue,
       subjects: null,
       selectedSubjects: []
@@ -74,23 +79,23 @@ const SubjectsStep = ({ btnsBox }) => {
     const id = getId(current)
     if (!id) return
 
-    const exist = data.selectedSubjects.some((s) => getId(s) === id)
+    const selected = data.selectedSubjects ?? []
+    const exist = selected.some((s) => getId(s) === id)
     if (exist) {
-      updateCategories({ subjects: null })
+      updateStep({ subjects: null })
       return
     }
 
-    updateCategories({
-      selectedSubjects: [...(data.selectedSubjects ?? []), current],
+    updateStep({
+      selectedSubjects: [...selected, current],
       subjects: null
     })
   }
 
   const removeChip = (id) => {
-    updateCategories({
-      selectedSubjects: (data.selectedSubjects ?? []).filter(
-        (s) => getId(s) !== id
-      )
+    const selected = data.selectedSubjects ?? []
+    updateStep({
+      selectedSubjects: selected.filter((s) => getId(s) !== id)
     })
   }
 
@@ -127,7 +132,7 @@ const SubjectsStep = ({ btnsBox }) => {
             clearOnEscape
             disabled={!data.category}
             loading={loadingSubjects}
-            onChange={(_, newValue) => updateCategories({ subjects: newValue })}
+            onChange={(_, newValue) => updateStep({ subjects: newValue })}
             onOpen={fetchSubjects}
             options={subjectsOptions}
             textFieldProps={{
@@ -148,7 +153,7 @@ const SubjectsStep = ({ btnsBox }) => {
 
           {!!data.selectedSubjects?.length && (
             <Stack sx={styles.chipWrap}>
-              {data.selectedSubjects.slice(0, 3).map((s) => {
+              {data.selectedSubjects.slice(0, MAX_VISIBLE_CHIPS).map((s) => {
                 const id = getId(s)
                 return (
                   <Chip
@@ -159,9 +164,9 @@ const SubjectsStep = ({ btnsBox }) => {
                   />
                 )
               })}
-              {data.selectedSubjects.length > 3 && (
+              {data.selectedSubjects.length > MAX_VISIBLE_CHIPS && (
                 <Chip
-                  label={`+${data.selectedSubjects.length - 3}`}
+                  label={`+${data.selectedSubjects.length - MAX_VISIBLE_CHIPS}`}
                   sx={styles.moreChip}
                 />
               )}

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
@@ -1,4 +1,5 @@
 import { fadeAnimation } from '~/styles/app-theme/custom-animations'
+import palette from '~/styles/app-theme/app.pallete'
 
 export const styles = {
   container: {
@@ -39,5 +40,11 @@ export const styles = {
     display: 'flex',
     flexDirection: 'column',
     gap: '16px'
+  },
+  addBtn: {
+    backgroundColor: palette.basic.grey,
+    fontSize: { xs: '14px', sm: '16px' },
+    lineHeight: { xs: '20px', sm: '24px' },
+    fontWeight: 500
   }
 }


### PR DESCRIPTION
-Added button
-Added chip rendering and delete logic.
-Added +N chip counter when subjects > 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subject selections display as removable chips for easier management
  * Add button enables only when a subject is selected and not already added
  * First three selected subjects display individually; additional selections shown in a summary chip
  * Remove individual subject chips with delete actions
  * Changing categories resets all subject selections

* **Style**
  * Updated styling for the Add button (colors, responsive typography)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->