### PR TITLE
fix: scroll to welcome block when clicking logo

### DIFF
--- a/src/containers/layout/navbar/NavBar.tsx
+++ b/src/containers/layout/navbar/NavBar.tsx
@@ -104,6 +104,13 @@ const Navbar = () => {
     <Box sx={styles.header}>
       <Button
         component={Link}
+        onClick={(e) => {
+          if (pathname === guestRoutes.home.path) {
+            e.preventDefault()
+            const el = document.getElementById('welcome')
+            el?.scrollIntoView({ behavior: 'smooth' })
+          }
+        }}
         size={SizeEnum.Small}
         sx={styles.logoButton}
         to={guestRoutes.home.path}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Logo click on the home page now smoothly scrolls to the welcome section instead of navigating away, improving navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->